### PR TITLE
Initial version of the tmpreaper puppet module

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+.ruby-version
+Gemfile.lock
+.kitchen/

--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -1,0 +1,20 @@
+---
+driver:
+  name: docker
+
+provisioner:
+  name: puppet_apply
+  require_chef_for_busser: false
+  manifests_path: .
+  modules_path: ../
+
+verifier:
+  name: inspec
+
+platforms:
+  - name: ubuntu-14.04
+
+suites:
+  - name: default
+    provisioner:
+      manifest: site.pp

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,12 @@
+---
+language: ruby
+before_install: rm Gemfile.lock || true
+bundler_args: --without functional_tests
+script: bundle exec rake test
+matrix:
+  fast_finish: true
+  include:
+    - rvm: 1.9.3
+      env: PUPPET_VERSION="~> 3.8.0"
+    - rvm: 2.4.0
+      env: PUPPET_VERSION="~> 5.2.0"

--- a/Gemfile
+++ b/Gemfile
@@ -1,0 +1,16 @@
+source 'https://rubygems.org'
+
+gem 'puppet', ENV['PUPPET_VERSION'] || '~> 5.2.0'
+
+gem 'rake', '~> 12.1.0'
+gem 'puppet-lint', '~> 2.3.3'
+gem 'rspec-puppet', '~> 2.6.9'
+gem 'puppetlabs_spec_helper', '~> 2.3.2'
+gem 'puppet-syntax', '~> 2.4.1'
+
+group :functional_tests do
+  gem 'test-kitchen'
+  gem 'kitchen-docker'
+  gem 'kitchen-inspec'
+  gem 'kitchen-puppet'
+end

--- a/README.md
+++ b/README.md
@@ -1,2 +1,3 @@
 # puppet-govuk_tmpreaper
+
 Puppet module used by GOV.UK to manage tmpreaper

--- a/Rakefile
+++ b/Rakefile
@@ -1,0 +1,12 @@
+require 'puppetlabs_spec_helper/rake_tasks'
+require 'puppet-lint/tasks/puppet-lint'
+require 'puppet-syntax/tasks/puppet-syntax'
+
+PuppetLint.configuration.fail_on_warnings = true
+
+desc "Run syntax, lint, and spec tests."
+task :test => [
+  :syntax,
+  :lint,
+  :spec,
+]

--- a/files/tmpreaper.conf
+++ b/files/tmpreaper.conf
@@ -1,0 +1,34 @@
+# tmpreaper.conf
+
+# TMPREAPER_TIME
+#       is the max. age of files before they're removed.
+#       default:
+#       the TMPTIME value in /etc/default/rcS if it's there, else
+#       TMPREAPER_TIME=7d (for 7 days)
+#       I recommend setting the value in /etc/default/rcS, as
+#       that is used to clean out /tmp whenever the system is booted.
+#
+# TMPREAPER_PROTECT_EXTRA
+#       are extra patterns that you may want to protect.
+#       Example:
+#       TMPREAPER_PROTECT_EXTRA='/tmp/isdnctrl* /tmp/important*'
+#
+# TMPREAPER_DIRS
+#       are the directories to clean up.
+#       *never* supply / here! That will wipe most of your system!
+#       Example:
+#       TMPREAPER_DIRS='/tmp/. /var/tmp/.'
+#
+# TMPREAPER_DELAY
+#       defines the maximum (randomized) delay before starting processing.
+#       See the manpage entry for --delay. Default is 256.
+#       Example:
+#       TMPREAPER_DELAY='256'
+#
+# TMPREAPER_ADDITIONALOPTIONS
+#       extra options that are passed to tmpreaper, e.g. --all
+
+TMPREAPER_PROTECT_EXTRA=''
+TMPREAPER_DIRS='/tmp/. /var/tmp/.'
+TMPREAPER_DELAY='256'
+TMPREAPER_ADDITIONALOPTIONS=''

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -1,0 +1,16 @@
+# == Class: govuk_tmpreaper
+#
+# Class to install and configure tmpreaper
+#
+class govuk_tmpreaper {
+
+  package { 'tmpreaper':
+    ensure => present,
+  }
+
+  file { '/etc/tmpreaper.conf':
+    ensure  => present,
+    content => file('govuk_tmpreaper/tmpreaper.conf'),
+  }
+
+}

--- a/site.pp
+++ b/site.pp
@@ -1,0 +1,1 @@
+include ::govuk_tmpreaper

--- a/spec/classes/tmpreaper_spec.rb
+++ b/spec/classes/tmpreaper_spec.rb
@@ -1,0 +1,10 @@
+require_relative '../spec_helper'
+
+describe 'govuk_tmpreaper', :type => :class do
+
+  it { is_expected.to compile }
+
+  it { is_expected.to compile.with_all_deps }
+
+  it { is_expected.to contain_class('govuk_tmpreaper') }
+end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,0 +1,1 @@
+require 'puppetlabs_spec_helper/module_spec_helper'

--- a/test/integration/default/govuk_tmpreaper_spec.rb
+++ b/test/integration/default/govuk_tmpreaper_spec.rb
@@ -1,0 +1,7 @@
+describe package('tmpreaper') do
+  it { should be_installed }
+end
+
+describe file('/etc/tmpreaper.conf') do
+  its('content') { should match(%r{TMPREAPER_DELAY='256'}) }
+end


### PR DESCRIPTION
This is an extraction of the code from https://github.com/alphagov/govuk-puppet/tree/c09c8d7406b947729d7fa0daeb6cb7e81771ed72/modules/tmpreaper with the addition of tests, updated ruby versions and Kitchen CI config